### PR TITLE
Put "on hold" notice into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# THIS PROJECT IS ON HOLD
+
+This project is not actively developed, maintained or supported at the moment. It is not recommended for production use.
+
+For a working Telegram bridge, please check out https://github.com/tulir/mautrix-telegram
+
+
+# ARCHIVED README
+
 Installation
 ------------
 


### PR DESCRIPTION
It seems this repository isn't currently maintained. Add a note about that, and helpfully point users to the excellent mautrix-telegram bridge, which is probably what they are looking for.